### PR TITLE
ENG-24954 limit license info

### DIFF
--- a/dashboards/Volt-V13.x/new-metrics/voltdb-configuration.json
+++ b/dashboards/Volt-V13.x/new-metrics/voltdb-configuration.json
@@ -1559,117 +1559,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [
-            {
-              "options": {
-                "features_commandlogging": {
-                  "index": 0,
-                  "text": "license supports the use of command logging"
-                },
-                "features_dractiveactive": {
-                  "index": 1,
-                  "text": "license supports the use of cross data center replication (XDCR)"
-                },
-                "features_drreplication": {
-                  "index": 2,
-                  "text": "license supports the use of passive database replication (DR)"
-                },
-                "features_trial": {
-                  "index": 3,
-                  "text": "whether this is a trial license or not"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "value"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 110
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 9,
-        "x": 0,
-        "y": 24
-      },
-      "id": 30,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": false
-      },
-      "pluginVersion": "9.5.3",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max (voltdb_systeminformation_license_info{v2=\"1\", namespace=\"$cluster\", host_name=~\"$host\"}) by (features_commandlogging, features_dractiveactive, features_drreplication, features_trial)",
-          "format": "time_series",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "License overview",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "rows"
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1686,7 +1575,7 @@
       "gridPos": {
         "h": 5,
         "w": 4,
-        "x": 9,
+        "x": 0,
         "y": 24
       },
       "id": 2,
@@ -1782,7 +1671,7 @@
       "gridPos": {
         "h": 5,
         "w": 4,
-        "x": 13,
+        "x": 4,
         "y": 24
       },
       "id": 28,
@@ -1882,7 +1771,7 @@
       "gridPos": {
         "h": 5,
         "w": 3,
-        "x": 17,
+        "x": 8,
         "y": 24
       },
       "id": 31,
@@ -1983,7 +1872,7 @@
       "gridPos": {
         "h": 5,
         "w": 4,
-        "x": 20,
+        "x": 11,
         "y": 24
       },
       "id": 32,
@@ -2105,6 +1994,6 @@
   "timezone": "",
   "title": "VoltDb Configuration",
   "uid": "iQGr28yVz",
-  "version": 38,
+  "version": 39,
   "weekStart": ""
 }


### PR DESCRIPTION
Due to recent license work exposing hardcoded set of license features becomes tricky and less useful. Presenting the license details in the Grafana dashboard seems to be of little use. Note that expiration time and host limits will be still reported.