### PR TITLE
Overview Transactions/s headline: client transactions, not fan-out

### DIFF
--- a/dashboards/Volt-V13.x/voltdb-cluster-overview.json
+++ b/dashboards/Volt-V13.x/voltdb-cluster-overview.json
@@ -2092,7 +2092,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "The rate of stored-procedure executions the cluster is running per second - the headline measure of how busy the database is. In a K-safe cluster each transaction fans out to every copy of its partition, so this counts each transaction once per copy and runs higher than the client transaction rate.",
+      "description": "The rate of transactions the cluster is executing per second, counted once per client request - the headline measure of client load. The Procedure calls tile next to it counts every execution including the fan-out to partition copies, so it runs higher; a growing gap between the two means more replicated or multi-partition work per transaction.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2150,7 +2150,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(voltdb_procedure_invoked_total{namespace=\"$cluster\",host_name=~\"$host\"}[$__rate_interval]))",
+          "expr": "sum(rate(voltdb_initiator_procedure_invoked_total{namespace=\"$cluster\",host_name=~\"$host\"}[$__rate_interval]))",
           "format": "time_series",
           "instant": false,
           "interval": "",

--- a/dashboards/Volt-V14.x/voltdb-cluster-overview.json
+++ b/dashboards/Volt-V14.x/voltdb-cluster-overview.json
@@ -2092,7 +2092,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "The rate of stored-procedure executions the cluster is running per second - the headline measure of how busy the database is. In a K-safe cluster each transaction fans out to every copy of its partition, so this counts each transaction once per copy and runs higher than the client transaction rate.",
+      "description": "The rate of transactions the cluster is executing per second, counted once per client request - the headline measure of client load. The Procedure calls tile next to it counts every execution including the fan-out to partition copies, so it runs higher; a growing gap between the two means more replicated or multi-partition work per transaction.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2150,7 +2150,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(voltdb_procedure_invoked_total{namespace=\"$cluster\",host_name=~\"$host\"}[$__rate_interval]))",
+          "expr": "sum(rate(voltdb_initiator_procedure_invoked_total{namespace=\"$cluster\",host_name=~\"$host\"}[$__rate_interval]))",
           "format": "time_series",
           "instant": false,
           "interval": "",

--- a/dashboards/Volt-V15.x/voltdb-cluster-overview.json
+++ b/dashboards/Volt-V15.x/voltdb-cluster-overview.json
@@ -2092,7 +2092,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "The rate of stored-procedure executions the cluster is running per second - the headline measure of how busy the database is. In a K-safe cluster each transaction fans out to every copy of its partition, so this counts each transaction once per copy and runs higher than the client transaction rate.",
+      "description": "The rate of transactions the cluster is executing per second, counted once per client request - the headline measure of client load. The Procedure calls tile next to it counts every execution including the fan-out to partition copies, so it runs higher; a growing gap between the two means more replicated or multi-partition work per transaction.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2150,7 +2150,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(voltdb_procedure_invoked_total{namespace=\"$cluster\",host_name=~\"$host\"}[$__rate_interval]))",
+          "expr": "sum(rate(voltdb_initiator_procedure_invoked_total{namespace=\"$cluster\",host_name=~\"$host\"}[$__rate_interval]))",
           "format": "time_series",
           "instant": false,
           "interval": "",


### PR DESCRIPTION
The overview's headline **Transactions/s** tile ran the identical query to the **Procedure calls** tile next to it — `sum(rate(voltdb_procedure_invoked_total))` — so it showed executions including K-safety fan-out and MP amplification, not client transactions (harness: 1091/s shown vs 370/s actually submitted, ~3x at K=1).

Now uses `voltdb_initiator_procedure_invoked_total` (counted once per client request), matching the client-experience convention used by the latency and error panels. The two tiles are no longer duplicates: their gap now visualizes per-transaction fan-out, and the description says so.

Applied to V15/V14/V13. Verified live against the 13.3.16 harness.