### PR TITLE
snapshots: show "in progress" instead of "-56 years" for unfinished Duration

### DIFF
--- a/dashboards/Volt-V13.x/voltdb-snapshots.json
+++ b/dashboards/Volt-V13.x/voltdb-snapshots.json
@@ -1418,6 +1418,22 @@
               },
               {
                 "id": "custom.filterable"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "range",
+                    "options": {
+                      "from": -1000000000000000.0,
+                      "to": -1,
+                      "result": {
+                        "text": "in progress",
+                        "index": 0
+                      }
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -1818,6 +1834,22 @@
               },
               {
                 "id": "custom.filterable"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "range",
+                    "options": {
+                      "from": -1000000000000000.0,
+                      "to": -1,
+                      "result": {
+                        "text": "in progress",
+                        "index": 0
+                      }
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -2236,6 +2268,22 @@
               },
               {
                 "id": "custom.filterable"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "range",
+                    "options": {
+                      "from": -1000000000000000.0,
+                      "to": -1,
+                      "result": {
+                        "text": "in progress",
+                        "index": 0
+                      }
+                    }
+                  }
+                ]
               }
             ]
           },

--- a/dashboards/Volt-V14.x/voltdb-snapshots.json
+++ b/dashboards/Volt-V14.x/voltdb-snapshots.json
@@ -1418,6 +1418,22 @@
               },
               {
                 "id": "custom.filterable"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "range",
+                    "options": {
+                      "from": -1000000000000000.0,
+                      "to": -1,
+                      "result": {
+                        "text": "in progress",
+                        "index": 0
+                      }
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -1818,6 +1834,22 @@
               },
               {
                 "id": "custom.filterable"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "range",
+                    "options": {
+                      "from": -1000000000000000.0,
+                      "to": -1,
+                      "result": {
+                        "text": "in progress",
+                        "index": 0
+                      }
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -2236,6 +2268,22 @@
               },
               {
                 "id": "custom.filterable"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "range",
+                    "options": {
+                      "from": -1000000000000000.0,
+                      "to": -1,
+                      "result": {
+                        "text": "in progress",
+                        "index": 0
+                      }
+                    }
+                  }
+                ]
               }
             ]
           },

--- a/dashboards/Volt-V15.x/voltdb-snapshots.json
+++ b/dashboards/Volt-V15.x/voltdb-snapshots.json
@@ -1418,6 +1418,22 @@
               },
               {
                 "id": "custom.filterable"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "range",
+                    "options": {
+                      "from": -1000000000000000.0,
+                      "to": -1,
+                      "result": {
+                        "text": "in progress",
+                        "index": 0
+                      }
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -1818,6 +1834,22 @@
               },
               {
                 "id": "custom.filterable"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "range",
+                    "options": {
+                      "from": -1000000000000000.0,
+                      "to": -1,
+                      "result": {
+                        "text": "in progress",
+                        "index": 0
+                      }
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -2236,6 +2268,22 @@
               },
               {
                 "id": "custom.filterable"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "range",
+                    "options": {
+                      "from": -1000000000000000.0,
+                      "to": -1,
+                      "result": {
+                        "text": "in progress",
+                        "index": 0
+                      }
+                    }
+                  }
+                ]
               }
             ]
           },


### PR DESCRIPTION
The snapshot tables compute `Duration = snapshot_end_time - snapshot_start_time`. While a snapshot is running, `end_time` is 0, so the column showed `-<epoch start>` rendered as "56 years (ago)". Grafana transformations cannot compute `now - start`, so a range value mapping now renders any negative duration as **in progress**. Applied to every Duration / "Duration so far" column in the snapshot tables, V15/V14/V13.